### PR TITLE
Patch triggerMesh and intersections

### DIFF
--- a/src/scripts/scenes/home.js
+++ b/src/scripts/scenes/home.js
@@ -145,7 +145,7 @@ export default class HomeScene extends XrScene {
       if (this.debug) console.log(intersection);
       this.material.color.set(0x00FF00);
 
-      //Functions call example
+      // Functions call example
       this.functions.externalFunc(intersection);
     };
 

--- a/src/scripts/scenes/home.js
+++ b/src/scripts/scenes/home.js
@@ -127,6 +127,13 @@ export default class HomeScene extends XrScene {
     const box = new TriggerMesh(geometry, material);
     if (!box) console.log('Failed to create box mesh');
 
+    const externalFunc = (args) => {
+      console.log(args);
+      console.log(this);
+    };
+
+    box.addFunction('externalFunc', externalFunc);
+
     box.hover = function (intersection) {
       if (this.debug) console.log(intersection);
       if (!this.isSelected) {
@@ -137,6 +144,9 @@ export default class HomeScene extends XrScene {
     box.select = function (intersection) {
       if (this.debug) console.log(intersection);
       this.material.color.set(0x00FF00);
+
+      //Functions call example
+      this.functions.externalFunc(intersection);
     };
 
     box.release = function (intersection) {

--- a/src/scripts/scenes/xr-scene.js
+++ b/src/scripts/scenes/xr-scene.js
@@ -368,6 +368,13 @@ export default class XrScene {
     const intersection = getIntersection(this.triggers);
 
     if (intersection) {
+      // Ensure that keyboard/mouse is not enabled before applying inverse world matrix to point
+      if (!(controls && controls.enabled)) {
+        // Fix the intersection point as it is in world coordinates
+        // rather than scene local coordinates
+        intersection.point.applyMatrix4(new Matrix4().getInverse(this.scene.matrixWorld));
+      }
+
       intersection.object.onTriggerHover(intersection);
       if (!intersection.object.isSelected) {
         if (this.buttonPressed) {

--- a/src/scripts/trigger.js
+++ b/src/scripts/trigger.js
@@ -27,7 +27,7 @@ export default class TriggerMesh extends Mesh {
      * Adds a function to the function list.
      * Useful for calling functions with their own contexts
      * (i.e. arrow functions)
-     * Call a function: this.functions[key](params);
+     * Call a function: this.functions.key(params);
      * @param {String} key
      * @param {Function} func
      */

--- a/src/scripts/trigger.js
+++ b/src/scripts/trigger.js
@@ -21,6 +21,20 @@ export default class TriggerMesh extends Mesh {
 
     release;
 
+    functions = {};
+
+    /**
+     * Adds a function to the function list.
+     * Useful for calling functions with their own contexts
+     * (i.e. arrow functions)
+     * Call a function: this.functions[key](params);
+     * @param {String} key
+     * @param {Function} func
+     */
+    addFunction(key, func) {
+      this.functions[key] = func;
+    }
+
     /**
      * Override of Object3D.clone() to include the object callbacks and material
      */
@@ -31,6 +45,7 @@ export default class TriggerMesh extends Mesh {
       triggerMesh.exit = this.exit;
       triggerMesh.select = this.select;
       triggerMesh.release = this.release;
+      triggerMesh.functions = this.functions;
       return triggerMesh;
     }
 


### PR DESCRIPTION
1. Updates the intersection.point such that it is expressed in scene local coordinates rather than world coordinates when passed into the trigger event functions.

2. In some cases, we need to call external functions in our trigger events that require a context other than the current `TriggerMesh`. A functions member and a companion `addFunction(key, func)` adds a function to a `TriggerMesh` in a key/value pair.

### Example
```javascript
   const externalFunc = (args) => {
      console.log(args);
      console.log(this);
    };

    box.addFunction('externalFunc', externalFunc);

    box.select = function (intersection) {
      if (this.debug) console.log(intersection);
      this.material.color.set(0x00FF00);

      // Functions call example
      this.functions.externalFunc(intersection);
    };
```