### PR TITLE
Fix due to latest WebXR API changes.

### DIFF
--- a/src/scripts/scenes/xr-scene.js
+++ b/src/scripts/scenes/xr-scene.js
@@ -266,7 +266,8 @@ export default class XrScene {
         for (let i = 0; i < pose.views.length; i++) {
           const view = pose.views[i];
           const viewport = XR.session.renderState.baseLayer.getViewport(view);
-          const viewMatrix = new Matrix4().fromArray(view.viewMatrix);
+          const viewMatrix = new Matrix4().fromArray(view.transform.matrix);
+          viewMatrix.getInverse(viewMatrix);
 
           this.renderer.context.viewport(
             viewport.x,


### PR DESCRIPTION
viewMatrix is gone, it's not part of the transform. It needs to be
inverted to represent the same values as before.