### PR TITLE
Fix for gravity direction sphere with gaze controls

### DIFF
--- a/src/scripts/scenes/kinematics.js
+++ b/src/scripts/scenes/kinematics.js
@@ -300,7 +300,6 @@ export default class KinematicsScene extends XrScene {
         let gravity = new THREE.Vector3();
         gravity.set(this.world.gravity.x, this.world.gravity.y, this.world.gravity.z);
         const scalar = gravity.length();
-        console.log(scalar);
 
         dir.multiplyScalar(scalar);
 

--- a/src/scripts/scenes/kinematics.js
+++ b/src/scripts/scenes/kinematics.js
@@ -286,11 +286,16 @@ export default class KinematicsScene extends XrScene {
       },
       drag: (matrix) => {
         const dir = new THREE.Vector3();
+        
+        if (this.scene.getObjectByName('controller')) {
+          const controller = this.scene.getObjectByName('controller');
+          controller.getWorldDirection(dir);
+          dir.negate();
+        } else {
+          this.camera.getWorldDirection(dir);
+        }
 
-        const controller = this.scene.getObjectByName('controller');
-        controller.getWorldDirection(dir);
-
-        gravityArrow.setDirection(dir.negate());
+        gravityArrow.setDirection(dir);
 
         let gravity = new THREE.Vector3();
         gravity.set(this.world.gravity.x, this.world.gravity.y, this.world.gravity.z);


### PR DESCRIPTION
Checks for a controller mesh and if none exists, then it uses camera direction instead.