### PR TITLE
Fix the demo with the latest Chrome Dev version

### DIFF
--- a/src/scripts/interactions.js
+++ b/src/scripts/interactions.js
@@ -58,7 +58,7 @@ function createRay(inputSource, xrFrame) {
 function handlerCommon(func) {
   return function ({ frame, inputSource }) {
     const ray = createRay(inputSource, frame);
-    if (ray) {
+    if (ray && ray.matrix) {
       func(raycast(ray)[0], inputSource, new Matrix4().fromArray(ray.matrix));
     }
   };
@@ -146,6 +146,8 @@ export function setupInteractions() {
 // Only have one Raycaster
 const raycaster = new Raycaster();
 function raycast(xrRay) {
+  if (!xrRay.matrix)
+    return;
   const { scene } = getCurrentScene();
 
   const trMatrix = new Matrix4().fromArray(xrRay.matrix);

--- a/src/scripts/xrController.js
+++ b/src/scripts/xrController.js
@@ -168,7 +168,7 @@ async function xrValidate() {
 
     // Check if device is capable of an immersive-vr sessions
     try {
-      await navigator.xr.supportsSessionMode('immersive-vr');
+      await navigator.xr.supportsSession('immersive-vr');
       createVRButton();
     } catch (reason) {
       console.log(`Device unable to support immersive-vr session : ${reason || ''}`);
@@ -176,7 +176,7 @@ async function xrValidate() {
 
     // Check to see if an non-immersive xr session is supported
     try {
-      await navigator.xr.supportsSessionMode('inline');
+      await navigator.xr.supportsSession('inline');
       showTouchControls();
       xrValidateMagicWindow();
     } catch (reason) {


### PR DESCRIPTION
(supportSessionMode -> supportSession).

Make sure to test the controller data because the
matrix can be undefined if the controller is found
but the tracking was not yet established. This fix
the Vive when the controllers are switched on after
being in immersive mode.